### PR TITLE
Fixed typo of Imprint (was: Inprint) and improved contrast of subtitles

### DIFF
--- a/assets/_includes/post_header.html
+++ b/assets/_includes/post_header.html
@@ -1,7 +1,7 @@
 <div class="page-header">
   <h1>
     <a class='episode_title' href='{{ site.url }}{{ post.url }}#{{ post.id | sha1:8 }}'>{{ post.title }}</a>
-    <small>{{ post.datum }}</small>
-    {% include disqus_count.html %}
-  </h1>
+    <small class='episode_date'>{{ post.datum }}</small> <br />
+    <small>{{ post.subtitle }}</small>
+  </h1>  
 </div>

--- a/assets/_sass/_overrides.scss
+++ b/assets/_sass/_overrides.scss
@@ -1,0 +1,13 @@
+// Improve visibility of subtitles and similar text by increasing contrast
+h1 small, h2 small, h3 small {
+  color: #77778C;
+}
+
+btn small, .btn small {
+  color: #2A2A2A;
+}
+
+// Making the date smaller improves the episode header when it includes the subtitle
+.episode_date {
+  font-size: 45%;
+}

--- a/assets/imprint.md
+++ b/assets/imprint.md
@@ -1,5 +1,5 @@
 ---
-title: Inprint
+title: Imprint
 layout: default
 navigation: 1
 ---


### PR DESCRIPTION
The English translation of "Impressum" is "Imprint", although that is not commonly used online. "Site notice" or "legal notice" might ultimately be better choices.

For now, fixing the typo should suffice :)