### PR TITLE
Included files for isso integration.

### DIFF
--- a/assets/_config.yml.sample
+++ b/assets/_config.yml.sample
@@ -37,6 +37,8 @@ disqus_shortname: # Disqus will not be used unless this is set
 disqus_developer: 0 # 1 / 0
 ## Itunes link ###########################################################
 itunes_url: "https://itunes.apple.com/at/podcast/myname/id#myid#"
+## Isso comments #########################################################
+use_isso: no # set to 'yes' to include isso comments form
 
 gems: [jekyll-octopod]
 theme: jekyll-bootflat

--- a/assets/_includes/isso_thread.html
+++ b/assets/_includes/isso_thread.html
@@ -1,0 +1,6 @@
+{% if site.use_isso == 'yes' %}
+<script data-isso="{{ site.url }}/isso/" src="{{ site.url }}/isso/js/embed.min.js"></script>
+
+<section id="isso-thread"></section>
+<noscript>Please enable JavaScript to view the <a href="https://posativ.org/isso">comments powered by Isso.</a></noscript>
+{% endif %}

--- a/assets/_includes/post.html
+++ b/assets/_includes/post.html
@@ -14,5 +14,6 @@
   {{ site | flattr_button:post }}
   <a href="https://twitter.com/share" class="twitter-share-button" data-url="{{ site.url }}{{post.url }}" data-text="{{ post.title }}">Tweet</a>
   {% unless page.url == '/index.html' %}{% include disqus_thread.html %}{% endunless %}
+  {% unless page.url == '/index.html' %}{% include isso_thread.html %}{% endunless %}
   <hr>
 </section>


### PR DESCRIPTION
Added configuration and files neccessary to integrate [isso](https://posativ.org/isso/) comments into an octopod site.