### PR TITLE
Add support for hosting audio files on an external server (issue 10).

### DIFF
--- a/assets/_config.yml.sample
+++ b/assets/_config.yml.sample
@@ -2,6 +2,7 @@
 title: Octopod
 # You should configure this ####################################################
 url: http://localhost:4000
+download_url: "http://your.fancy.hosting/episodes"
 subtitle: Static Site Podcast Publishing for Geeks
 description: My super duper cool podcast.
 author: Uncle Octopod

--- a/assets/_includes/post.html
+++ b/assets/_includes/post.html
@@ -4,10 +4,15 @@
 {% endif %}
 <section id="{{ post.id | sha1:8 }}" class="active">
   {% include post_header.html %}
+  {% if site.download_url == "" or site.download_url == nil %}
+    {% assign download_url = site.url | append: '/episodes' %}
+  {% else %}
+    {% assign download_url = site.download_url %}
+  {% endif %}
   {{ post.content }}
     {% if post.audio %}
       {% for file in post.audio %}
-      <a class="btn btn-primary" href="{{ site.download_url }}/{{ file.last }}">Download .{{ file.first }} ({{ file.last | file_size:'./' | string_of_size }})</a>
+      <a class="btn btn-primary" href="{{ download_url }}/{{ file.last }}">Download .{{ file.first }} ({{ file.last | file_size:'./' | string_of_size }})</a>
       {% endfor %}
     {% endif %}
   <hr>

--- a/assets/_includes/post.html
+++ b/assets/_includes/post.html
@@ -7,7 +7,7 @@
   {{ post.content }}
     {% if post.audio %}
       {% for file in post.audio %}
-      <a class="btn btn-primary" href="{{ site.url }}/episodes/{{ file.last }}">Download .{{ file.first }} ({{ file.last | file_size:'./' | string_of_size }})</a>
+      <a class="btn btn-primary" href="{{ site.download_url }}/{{ file.last }}">Download .{{ file.first }} ({{ file.last | file_size:'./' | string_of_size }})</a>
       {% endfor %}
     {% endif %}
   <hr>

--- a/assets/_layouts/feed.xml
+++ b/assets/_layouts/feed.xml
@@ -61,7 +61,7 @@ layout: null
             <guid isPermaLink="false">{{ site.url }}{{ post.url }}</guid>
             <description><![CDATA[{{ post.content | expand_urls: site.url | cdata_escape | remove_script_and_audio }}]]></description>
             <content:encoded><![CDATA[{{ post.content | expand_urls: site.url | cdata_escape | remove_script_and_audio }}]]></content:encoded>
-            {% assign url = site.url | append: '/episodes/' | append: post.audio[page.format] %}
+            {% assign url = site.download_url | append: '/' | append: post.audio[page.format] %}
             <enclosure url="{{ url }}" length="{{ post.audio | audio:page.format | file_size }}" type="{{ page.format | mime_type }}" guid="{{ url | sha1:32}}" />
             <itunes:keywords>{{ post.tags }}</itunes:keywords>
             <itunes:subtitle>{{ post.subtitle }}</itunes:subtitle>

--- a/assets/_layouts/feed.xml
+++ b/assets/_layouts/feed.xml
@@ -46,6 +46,11 @@ layout: null
     <itunes:category text="{{ category }}">
     {% endfor %}
     </itunes:category>
+    {% if site.download_url == "" or site.download_url == nil %}
+      {% assign download_url = site.url | append: '/episodes' %}
+    {% else %}
+      {% assign download_url = site.download_url %}
+    {% endif %}
     {% for post in site.posts %}
       {% if post.audio[page.format] %}
         {% assign check = forloop.index0 | divided_by:site.episodes_per_feed_page | plus: 1 %}
@@ -61,7 +66,7 @@ layout: null
             <guid isPermaLink="false">{{ site.url }}{{ post.url }}</guid>
             <description><![CDATA[{{ post.content | expand_urls: site.url | cdata_escape | remove_script_and_audio }}]]></description>
             <content:encoded><![CDATA[{{ post.content | expand_urls: site.url | cdata_escape | remove_script_and_audio }}]]></content:encoded>
-            {% assign url = site.download_url | append: '/' | append: post.audio[page.format] %}
+            {% assign url = download_url | append: '/' | append: post.audio[page.format] %}
             <enclosure url="{{ url }}" length="{{ post.audio | audio:page.format | file_size }}" type="{{ page.format | mime_type }}" guid="{{ url | sha1:32}}" />
             <itunes:keywords>{{ post.tags }}</itunes:keywords>
             <itunes:subtitle>{{ post.subtitle }}</itunes:subtitle>

--- a/assets/_layouts/player_index.html
+++ b/assets/_layouts/player_index.html
@@ -19,7 +19,7 @@ layout: null
   <meta property="og:image" content="{{ site.url }}/img/logo-360x360.png"/>
 
   {% for feed in site['episode_feed_formats'] %}
-    <meta property="og:audio" content="{{ site.url }}/episodes/{{ page['audio'][feed] }}"/>
+    <meta property="og:audio" content="{{ site.download_url }}/{{ page['audio'][feed] }}"/>
     <meta property="og:audio:type" content="audio/{{ feed }}"/>
   {% endfor %}
 </head>

--- a/assets/_layouts/player_index.html
+++ b/assets/_layouts/player_index.html
@@ -18,8 +18,13 @@ layout: null
   <meta property="og:description" content="{{ site.description }}"/>
   <meta property="og:image" content="{{ site.url }}/img/logo-360x360.png"/>
 
+  {% if site.download_url == "" or site.download_url == nil %}
+    {% assign download_url = site.url | append: '/episodes' %}
+  {% else %}
+    {% assign download_url = site.download_url %}
+  {% endif %}
   {% for feed in site['episode_feed_formats'] %}
-    <meta property="og:audio" content="{{ site.download_url }}/{{ page['audio'][feed] }}"/>
+    <meta property="og:audio" content="{{ download_url }}/{{ page['audio'][feed] }}"/>
     <meta property="og:audio:type" content="audio/{{ feed }}"/>
   {% endfor %}
 </head>

--- a/lib/jekyll/podigee_player_tag.rb
+++ b/lib/jekyll/podigee_player_tag.rb
@@ -5,7 +5,8 @@ module Jekyll
       page = context.registers[:page]
 
       audio = {}
-      page["audio"].each { |key, value| audio[key] = config["download_url"] + "/" + value}
+      download_url = config["download_url"] || config["url"] + "/episodes"
+      page["audio"].each { |key, value| audio[key] = download_url + "/" + value}
 
       { options: { theme: "default",
                    startPanel: "ChapterMarks" },

--- a/lib/jekyll/podigee_player_tag.rb
+++ b/lib/jekyll/podigee_player_tag.rb
@@ -5,7 +5,7 @@ module Jekyll
       page = context.registers[:page]
 
       audio = {}
-      page["audio"].each { |key, value| audio[key] = config["url"] + "/episodes/" + value}
+      page["audio"].each { |key, value| audio[key] = config["download_url"] + "/" + value}
 
       { options: { theme: "default",
                    startPanel: "ChapterMarks" },


### PR DESCRIPTION
Add support for hosting the audio files on some external server by means of a new `download_url `setting in `_config.yml`.