### PR TITLE
Only include a post's URL in the <guid> element, not the whole post's…

### DIFF
--- a/assets/_layouts/feed.xml
+++ b/assets/_layouts/feed.xml
@@ -64,7 +64,7 @@ layout: null
             {% for category in post.categories %}
             <category><![CDATA[{{ category }}]]></category>
             {% endfor %}
-            <guid isPermaLink="false">{{ site.url }}{{ post }}</guid>
+            <guid isPermaLink="false">{{ site.url }}{{ post.url }}</guid>
             <description><![CDATA[{{ post.content | expand_urls: site.url | cdata_escape | remove_script_and_audio }}]]></description>
             <content:encoded><![CDATA[{{ post.content | expand_urls: site.url | cdata_escape | remove_script_and_audio }}]]></content:encoded>
             {% assign url = download_url | append: '/' | append: post.audio[page.format] %}


### PR DESCRIPTION
… content. This avoids including things like the DOCTYPE definition inside of the <guid> element, which invalidates the feed's format.