### PR TITLE
Allow episodes with no chapters defined

### DIFF
--- a/lib/jekyll/podigee_player_tag.rb
+++ b/lib/jekyll/podigee_player_tag.rb
@@ -8,7 +8,7 @@ module Jekyll
       download_url = config["download_url"] || config["url"] + "/episodes"
       page["audio"].each { |key, value| audio[key] = download_url + "/" + value}
 
-      { options: { theme: "default",
+      config = { options: { theme: "default",
                    startPanel: "ChapterMarks" },
         extensions: { ChapterMarks: {},
                       EpisodeInfo:  {},
@@ -20,9 +20,13 @@ module Jekyll
                    subtitle: page["subtitle"],
                    url: config['url'] + page["url"],
                    description: page["description"],
-                   chaptermarks: page["chapters"] ? page["chapters"].map {|chapter| { start: chapter[0..12], title: chapter[13..255] }} : nil
                  }
-      }.to_json
+      }
+      if page.key?("chapters".to_sym)
+        config["episode"]["chaptermarks"] = page["chapters"].map {|chapter| { start: chapter[0..12], title: chapter[13..255] }}
+      end
+
+      config.to_json
     end
 
     def render(context)

--- a/lib/jekyll/podigee_player_tag.rb
+++ b/lib/jekyll/podigee_player_tag.rb
@@ -22,8 +22,8 @@ module Jekyll
                    description: page["description"],
                  }
       }
-      if page.key?("chapters".to_sym)
-        config["episode"]["chaptermarks"] = page["chapters"].map {|chapter| { start: chapter[0..12], title: chapter[13..255] }}
+      if page.key?("chapters")
+        config[:episode][:chaptermarks] = page["chapters"].map {|chapter| { start: chapter[0..12], title: chapter[13..255] }}
       end
 
       config.to_json


### PR DESCRIPTION
**Issue and Rationale**
Currently if an episode has no `chapter` element defined in its post front matter a build error results. This prevents publishing episodes with audio but no chapters defined. But it's valid to have episodes with audio files but no chapters defined. This is more likely porting from another platform to octopod where the other platform has no chapter support.

**Fix**
Add `key?` check to `lib/jekyll/podigee_player_tag.rb` where it builds the player config, so that if the episode has no `chapter` element defined in front matter the config is still built and returned.

**Tested**
Manually tested by both adding and removing the `chapter` element from front matter and rebuilding site and verifying that the player loads without chapters and with them, and that in the latter case the chapters are displayed.