### PR TITLE
Revert "Allow episodes with no chapters defined"

### DIFF
--- a/lib/jekyll/podigee_player_tag.rb
+++ b/lib/jekyll/podigee_player_tag.rb
@@ -8,7 +8,7 @@ module Jekyll
       download_url = config["download_url"] || config["url"] + "/episodes"
       page["audio"].each { |key, value| audio[key] = download_url + "/" + value}
 
-      config = { options: { theme: "default",
+      { options: { theme: "default",
                    startPanel: "ChapterMarks" },
         extensions: { ChapterMarks: {},
                       EpisodeInfo:  {},
@@ -20,13 +20,9 @@ module Jekyll
                    subtitle: page["subtitle"],
                    url: config['url'] + page["url"],
                    description: page["description"],
+                   chaptermarks: page["chapters"] ? page["chapters"].map {|chapter| { start: chapter[0..12], title: chapter[13..255] }} : nil
                  }
-      }
-      if page.key?("chapters")
-        config[:episode][:chaptermarks] = page["chapters"].map {|chapter| { start: chapter[0..12], title: chapter[13..255] }}
-      end
-
-      config.to_json
+      }.to_json
     end
 
     def render(context)


### PR DESCRIPTION
Reverts jekyll-octopod/jekyll-octopod#45

Actually this created a regression, not having chapters was fixed before.