### PR TITLE
Support front-matter configuration of podigee player theme

### DIFF
--- a/lib/jekyll/podigee_player_tag.rb
+++ b/lib/jekyll/podigee_player_tag.rb
@@ -1,5 +1,8 @@
 module Jekyll
   class PodigeePlayerTag < Liquid::Tag
+    # From here: https://github.com/podigee/podigee-podcast-player/tree/master/src/themes
+    PLAYER_THEMES = ["default", "default-dark", "legacy", "minimal", "republica"]
+
     def playerconfig(context)
       config = context.registers[:site].config
       page = context.registers[:page]
@@ -7,8 +10,8 @@ module Jekyll
       audio = {}
       download_url = config["download_url"] || config["url"] + "/episodes"
       page["audio"].each { |key, value| audio[key] = download_url + "/" + value}
-
-      { options: { theme: "default",
+ 
+      { options: { theme: page["player_theme"] && PLAYER_THEMES.include?(page["player_theme"]) ? page["player_theme"] : "default",
                    startPanel: "ChapterMarks" },
         extensions: { ChapterMarks: {},
                       EpisodeInfo:  {},


### PR DESCRIPTION
Supports a new `post` front matter element, `player_theme`, which, if present, the `podigee_player_tag.rb` module will use to set the theme for the podigee player. The currently available themes are all supported. If the element is not present or not a valid string matching one of the supported themes, the "default" theme value is used.